### PR TITLE
Remove the flow parser from the recommended Prettier config

### DIFF
--- a/Guidelines/Repository Setup.md
+++ b/Guidelines/Repository Setup.md
@@ -24,8 +24,7 @@ Create a `.prettierrc` file at the root of the repository with this content:
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "jsxBracketSameLine": true,
-  "parser": "flow"
+  "jsxBracketSameLine": true
 }
 ```
 


### PR DESCRIPTION
This is not needed as Prettier picks the correct parser based on the file type (defaulting to `flow` for `js`, `typescript` for `ts` and `tsx` etc.). Hard coding it like this causes subtle issues with repos with mixed or purely Typescript code like this:

https://github.com/typescript-eslint/typescript-eslint/issues/481

Removing this does not affect users of Flow as it will be the default for JS files.