### PR TITLE
Adding the stale.yml based on react-native core and react-native-share

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -28,7 +28,7 @@ staleLabel: stale
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions. You may also mark this issue as a "discussion" and i
+  for your contributions. You may also mark this issue as a "discussion" and I
   will leave this open.
  # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,41 @@
+# Configuration for probot-stale based on: https://github.com/facebook/react-native/blob/master/.github/stale.yml
+
+ # Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+ # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 7
+
+ # Issues or Pull Requests.
+exemptLabels:
+  - pinned
+  - security
+  - discussion
+
+ # Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+ # Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+ # Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+ # Label to use when marking as stale
+staleLabel: stale
+
+ # Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions. You may also mark this issue as a "discussion" and i
+  will leave this open.
+ # Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Closing this issue after a prolonged period of inactivity. Fell free to reopen
+  this issue, if this still affecting you.
+ # Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+ # Limit to only `issues` or `pulls`
+only: issues 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
As discussed on https://github.com/react-native-community/react-native-share/pull/503. I added a simple stale.yml using pro-bot stale to handle old issues on [react-native-share](https://github.com/react-native-community/react-native-share). With @jgcmarins help, the pro-bot have been configured beign able to handle old issues without any problem.

# Motivation
Since there is a lot of issues open on react-native-share, i decided  with @jgcmarins  to add a simple stale bot to handle old issues By doing this, we got a reply from some issues, that dont have been given the properly attention. 

My suggestion is: would be interesting having a default stale.yml to be applied on the repos under react-native-community umbrella. We just need to ensure that these repos got some default labels like: 

  - pinned
  - security
  - pinned
  - discussion

By doing this, we can close old issues easily and see if there is been a reply from the author without having to read every issue on the repo.

Also, i think that setting some bots apart from the stale would be super productive, we can even use react-native as a base for this. :smile: 

Bwt, i hope this helps in further discussions. =D