### PR TITLE
feat: add detail for the `Changelog` section with best-practices

### DIFF
--- a/Guidelines/Repository Setup.md
+++ b/Guidelines/Repository Setup.md
@@ -44,6 +44,14 @@ It is recommended that you add this command to your `scripts` in your `package.j
 
 ## Changelog
 
+For each published project, there should be a `CHANGELOG.md` file in the root directory with a history of noteworthy changes. Please follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format for this file, but feel free to use tools like `semantic-release` or `conventional-changelog` to help. Strive to have the changelog published as part of your release process.
+
+The changelog is a great place to recognize code contributors. For that reason, consider attributing changes to their authors. However, beware of feeling pressure to list all changes in the changelog. It should be a curated view. For example don't list refactoring or CI changes, because they do not impact your users.
+
+For monorepos, we suggest keeping separate changelogs for each module that users would add as a dependency. Internal dependencies that you do not expect to be adopted may or may not need a changelog; you may find it beneficial to keep one for your fellow maintainers in complicated systems.
+
+Also, we suggest linking to your changelog in any GitHub releases descriptions rather than embedding the content. The changelog is a living document, and maintaining the same content across multiple places can be cumbersome.
+
 ## NPM
 
 ## Tagging


### PR DESCRIPTION
# Summary

I added some brief details on managing changeslogs to this document. It touches on a few topics that the Releasers have talked about in the past, and it also gives guidance on how to better managed a few community-specific areas like monorepos.