### PR TITLE
do not require prettier pragma

### DIFF
--- a/Guidelines/Repository Setup.md
+++ b/Guidelines/Repository Setup.md
@@ -20,7 +20,6 @@ Create a `.prettierrc` file at the root of the repository with this content:
 
 ```json
 {
-  "requirePragma": true,
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,


### PR DESCRIPTION
having the option set to true means all files to be checked by prettier need to have a `@format` comment at the top, but for community modules this seems unnecessary