### PR TITLE
specify the need for minimal runnable reproduction

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,15 +7,17 @@ about: Report a reproducible bug or regression in this library.
 
 <!--
   Please provide a clear and concise description of what the bug is.
-  Include screenshots if needed.
-  Please test using the latest release of the library, as maybe said bug has been already fixed.
-  If the library has multiple install methods, describe installation method (e.g., pod, not pod, with jetifier etc)
+  Include screenshots or gifs if needed.
+  Please test using the latest release of the library, as maybe your bug has been already fixed.
+  If the library has multiple install methods, describe installation method (e.g., pod, not pod, with jetifier etc).
+
+  **Please note that issues that do not follow the template may be closed.**
 -->
 
 ## Environment info
 
 <!--
-  Run `react-native info` in your terminal and copy the results here. Also, include the *precise* version number of this library that you are using in the project
+  Run `react-native info` in your terminal and paste the results here. Also, include the *precise* version number of this library that you are using in the project
 -->
 
 React native info output:
@@ -29,7 +31,10 @@ Library version: x.x.x
 ## Steps To Reproduce
 
 <!--
- Issues without reproduction steps or code are likely to stall.
+- You must provide an easy way to reproduce the problem.
+- Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. [Read more](https://stackoverflow.com/help/mcve).
+- Either re-create the bug using the repository's example app or link to a GitHub repository with code that reproduces the bug.
+- Explain the steps we need to take to reproduce the issue:
 -->
 
 1.
@@ -44,5 +49,5 @@ Describe what you expected to happen:
 ## Reproducible sample code
 
 <!--
- Please add to your issue a repro, a fresh codebase with the minimal changes so that the bug can be tested in isolation
+ Please add minimal runnable repro as explained above so that the bug can be tested in isolation.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ Library version: x.x.x
 
 <!--
 - You must provide an easy way to reproduce the problem.
-- Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. [Read more](https://stackoverflow.com/help/mcve).
+- Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. See https://stackoverflow.com/help/mcve.
 - Either re-create the bug using the repository's example app or link to a GitHub repository with code that reproduces the bug.
 - Explain the steps we need to take to reproduce the issue:
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ Library version: x.x.x
 ## Steps To Reproduce
 
 <!--
-- You must provide an clear list of steps to reproduce the problem.
+- You must provide a clear list of steps and code to reproduce the problem.
 - Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. See https://stackoverflow.com/help/mcve.
 - Either re-create the bug using the repository's example app or link to a GitHub repository with code that reproduces the bug.
 - Explain the steps we need to take to reproduce the issue:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ Library version: x.x.x
 ## Steps To Reproduce
 
 <!--
-- You must provide an easy way to reproduce the problem.
+- You must provide an clear list of steps to reproduce the problem.
 - Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. See https://stackoverflow.com/help/mcve.
 - Either re-create the bug using the repository's example app or link to a GitHub repository with code that reproduces the bug.
 - Explain the steps we need to take to reproduce the issue:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation: in order to fix bugs in the community libraries, we need "high quality issues" that allow maintainers to identify potential bugs quickly.

l propose to make the default bug report template more strict in the sense that we should make it clear that we require minimal runnable reproductions in the form of code snippets that can be copy-pasted and run, or links to repos with minimal repro (or snack - but how is it with native modules?). Reason is I'm seeing a lot of issues where people don't make enough effort to describe their problem and how to reproduce it. Such "low quality" issues then stall and I'd prefer to close them on the grounds of not following the template.

Many community repos have their own bug  template which won't be affected

opinions?
