### PR TITLE
docs: adding new maintainer to react-native-share

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -52,7 +52,7 @@
 | [react-native-platform-touchable](https://github.com/react-native-community/react-native-platform-touchable) | [@brentvatne](https://github.com/brentvatne) | inactive(?) |
 | [react-native-push-notification-ios](https://github.com/react-native-community/react-native-push-notification-ios) | [@rafaellincoln](https://github.com/rafaellincoln), [@Naturalclar](https://github.com/Naturalclar) | active |
 | [react-native-safe-area-view](https://github.com/react-native-community/react-native-safe-area-view) | [@brentvatne](https://github.com/brentvatne), [@cesargdm](https://github.com/cesargdm) | active |
-| [react-native-share](https://github.com/react-native-community/react-native-share) | [@jgcmarins](https://github.com/jgcmarins), [@mikehardy](https://github.com/mikehardy) | active |
+| [react-native-share](https://github.com/react-native-community/react-native-share) | [@jgcmarins](https://github.com/jgcmarins), [@mikehardy](https://github.com/mikehardy), [@MateusAndrade](https://github.com/MateusAndrade) | active |
 | [react-native-side-menu](https://github.com/react-native-community/react-native-side-menu) | [@Kureev](https://github.com/Kureev), [@hannigand](https://github.com/hannigand) | active |
 | [react-native-simple-share](https://github.com/react-native-community/react-native-simple-share) | [@Ansalibrahim](https://github.com/Ansalibrahim) | starting |
 | [react-native-slider](https://github.com/react-native-community/react-native-slider) | [@michalchudziak](https://github.com/michalchudziak) | active |


### PR DESCRIPTION
# Summary

Adding a new maintainer at https://github.com/react-native-community/react-native-share.