### PR TITLE
Improve issue template appealingness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,34 +1,34 @@
 ---
-name: '🐛 Bug Report'
+name: "🐛 Bug report"
 about: Report a reproducible bug or regression in this library.
 ---
 
-# Bug
+# Bug report
 
 <!--
-  Please provide a clear and concise description of what the bug is.
-  Include screenshots or gifs if needed.
-  Please test using the latest release of the library, as maybe your bug has been already fixed.
-  If the library has multiple install methods, describe installation method (e.g., pod, not pod, with jetifier etc).
+Please provide a clear and concise description of what the bug is.
+Include screenshots or gifs if needed.
+Please test using the latest release of the library, as maybe your bug has been already fixed.
+If the library has multiple install methods, describe installation method (e.g., pod, not pod, with jetifier etc).
 
-  **Please note that issues that do not follow the template may be closed.**
+**Please note that issues that do not follow the template may be closed.**
 -->
 
 ## Environment info
 
 <!--
-  Run `react-native info` in your terminal and paste the results here. Also, include the *precise* version number of this library that you are using in the project
+Run `react-native info` in your terminal and paste the results here. Also, include the *precise* version number of this library that you are using in the project.
 -->
 
 `react-native info` output:
 
 ```bash
- // paste it here
+# paste it here
 ```
 
 Library version: x.x.x
 
-## Steps To Reproduce
+## Steps to reproduce
 
 <!--
 - You must provide a clear list of steps and code to reproduce the problem.
@@ -37,17 +37,16 @@ Library version: x.x.x
 - Explain the steps we need to take to reproduce the issue:
 -->
 
-1.
-2.
-...
+1. …
+2. …
 
 Describe what you expected to happen:
 
-1.
-2.
+1. …
+2. …
 
 ## Reproducible sample code
 
 <!--
- Please add minimal runnable repro as explained above so that the bug can be tested in isolation.
+Please add minimal runnable repro as explained above so that the bug can be tested in isolation.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,10 @@ Before submitting a new issue, please:
 Still ready? Fill the template. 👇
 -->
 
+## Summary
+
 <!--
-▶️ First things first: Provide a clear and concise description of what the bug is.
+Provide a clear and concise description of what the bug is.
 -->
 
 ## Environment info

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Before submitting a new issue, please:
 
 - Test using the latest release of the library, as maybe your bug has been already fixed.
 - Check for possible duplicate issues, with possible answers.
-- Check on https://reactnative.directory if this package supports your targetted platform (Android, iOS, Expo, …)
+- Check on https://reactnative.directory if this package supports your target platform (Android, iOS, Expo, …)
 
 Still ready? Fill the template. 👇
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,12 +6,22 @@ about: Report a reproducible bug or regression in this library.
 # Bug report
 
 <!--
-Please provide a clear and concise description of what the bug is.
-Include screenshots or gifs if needed.
-Please test using the latest release of the library, as maybe your bug has been already fixed.
-If the library has multiple install methods, describe installation method (e.g., pod, not pod, with jetifier etc).
+👋 Hi!
 
-**Please note that issues that do not follow the template may be closed.**
+🚨 Please read the following carefully before opening a new issue. Your issue may
+be closed if it doesn't provide the required pieces of information. 🚨
+
+Before submitting a new issue, please:
+
+- Test using the latest release of the library, as maybe your bug has been already fixed.
+- Check for possible duplicate issues, with possible answers.
+- Check on https://reactnative.directory if this package supports your targetted platform (Android, iOS, Expo, …)
+
+Still ready? Fill the template. 👇
+-->
+
+<!--
+▶️ First things first: Provide a clear and concise description of what the bug is.
 -->
 
 ## Environment info
@@ -33,6 +43,7 @@ Library version: x.x.x
 <!--
 - You must provide a clear list of steps and code to reproduce the problem.
 - Keep the code reproducing the bug as simple as possible, with the minimum amount of code required to reproduce the issue. See https://stackoverflow.com/help/mcve.
+- If this library has additional install steps, describe them (e.g., pod install? jetify? etc).
 - Either re-create the bug using the repository's example app or link to a GitHub repository with code that reproduces the bug.
 - Explain the steps we need to take to reproduce the issue:
 -->
@@ -49,4 +60,5 @@ Describe what you expected to happen:
 
 <!--
 Please add minimal runnable repro as explained above so that the bug can be tested in isolation.
+If needed, you can also provide other samples: error messages / stack traces, screenshots, gifs, etc.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,28 +1,28 @@
 ---
-name: '💡 Feature Request'
+name: "💡 Feature request"
 about: Submit your idea for a change in the codebase.
 ---
 
-# Feature Request
+# Feature request
 
 <!--
-  This issue should serve for you to present or pitch an idea to the maintainers - but remember that it would be better if you were to submit a PR instead 🤗
+This issue should serve for you to present or pitch an idea to the maintainers - but remember that it would be better if you were to submit a PR instead 🤗
 -->
 
 ## Why it is needed
 
 <!--
-  Please tell us a bit more of why you want this feature to be added, what's its origin
+Please tell us a bit more of why you want this feature to be added, what's its origin.
 -->
 
 ## Possible implementation
 
 <!--
-  It really helps if you could describe from a technical POV how this new feature would work, which code it rely on, etc
+It really helps if you could describe from a technical POV how this new feature would work, which code it rely on, etc.
 -->
 
 ### Code sample
 
 <!--
-  Please show how the new code could work, if doable
+Please show how the new code could work, if doable.
 -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,13 +1,14 @@
 ---
-name: '🤔 Questions and Help'
+name: "🤔 Questions and help"
 about: Use this if there is something not clear about the code or its docs.
 ---
 
 # Question
 
 <!--
-  Before submitting it, please ensure that this was not already asked in another issue, or on StackOverflow. Ideally, you should always refer to StackOverflow first.
+Before submitting it, please ensure that this was not already asked in another issue, or on StackOverflow. Ideally, you should always refer to StackOverflow first.
 
-  This issue should serve for you to ask a question about the library to the maintainers and other fellow developers - remember that even if the issue gets closed, the conversation can move forward 🤗
-  Also, ideally this issue should culminate in a PR to the documentation for this library so that future developers will have that doubt cleared.
+This issue should serve for you to ask a question about the library to the maintainers and other fellow developers - remember that even if the issue gets closed, the conversation can move forward 🤗
+
+Also, ideally this issue should culminate in a PR to the documentation for this library so that future developers will have that doubt cleared.
 -->


### PR DESCRIPTION
# Summary

Following a discussion with @brentvatne, we agreed on would be nice to improve a bit the default issue template (remind to check for duplicates, compatibility).

Often, I see the templates not respected, deleted immediately. It makes everyone lose time (the lib user and the maintainers).

I know it should be common practice to just close the issues in question, but IMHO it's not ideal and it might seem harsh to newcomers. So I tried making the bug report a bit more appealing to _maybe_ improve the conversation rate.

PS: Note that English is not my primary language 😅